### PR TITLE
Switched from busybox to very basic container

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -29,12 +29,12 @@ resource "aws_instance" "example" {
                 EOF
     
     tags {
-        Name = "busybox-test-server"
+        Name = "test-server"
     }
 }
 
 resource "aws_security_group" "instance" {
-    name = "busybox-example-instance"
+    name = "example-instance"
 
     ingress {
         from_port = "${var.server_port}"

--- a/main.tf
+++ b/main.tf
@@ -1,6 +1,6 @@
 variable "server_port" {
     description = "port for HTTP requests"
-    default = 8080
+    default = 8888
 }
 
 output "public_ip" {
@@ -21,10 +21,11 @@ resource "aws_instance" "example" {
     user_data = <<-EOF
                 #!/bin/bash
                 apt-get -y update
+                apt-get -y upgrade
                 apt-get -y install git
-                git clone https://github.com/EvanKDodge/website.git
-                cd website
-                nohup busybox httpd -f -p "${var.server_port}" &
+                curl -fsSL get.docker.com | sh
+                git clone https://github.com/EvanKDodge/website.git /var/www/html
+                docker container run --name web1 -v /var/www/html:/usr/share/nginx/html -p "${var.server_port}":80 -d nginx
                 EOF
     
     tags {


### PR DESCRIPTION
I started off by just firing up busybox on ubuntu and using that as my webserver. Now I've got the server running inside of a container. The git clone is also putting the data into a more logical place (was /website, now it /var/www/html).